### PR TITLE
文档中的示例程序有点问题

### DIFF
--- a/operating-system/os-processandthread.md
+++ b/operating-system/os-processandthread.md
@@ -535,7 +535,7 @@ int main(int argc,char *argv[]){
 
 ```c
 while(TRUE){
-  while(turn != 0){
+  while(turn == 0){
     /* 进入关键区域 */
     critical_region();
     turn = 1;
@@ -549,7 +549,7 @@ while(TRUE){
 
 ```c
 while(TRUE){
-  while(turn != 1){
+  while(turn == 1){
     critical_region();
     turn = 0;
     noncritical_region();


### PR DESCRIPTION
按照描述应该是进程 0 判断 `turn == 0` 时才会进入循环，同理进程 1 也是。